### PR TITLE
Draft implementation of H5S_PLIST and H5Pset_dataset_io_hyperslab_selection

### DIFF
--- a/src/H5Dprivate.h
+++ b/src/H5Dprivate.h
@@ -84,6 +84,7 @@
 #define H5D_XFER_FILTER_CB_NAME "filter_cb"      /* Filter callback function */
 #define H5D_XFER_CONV_CB_NAME   "type_conv_cb"   /* Type conversion callback function */
 #define H5D_XFER_XFORM_NAME     "data_transform" /* Data transform */
+#define H5D_XFER_DSET_IO_SEL_NAME "dset_io_selection" /* Dataset I/O selection */
 #ifdef H5_HAVE_INSTRUMENTED_LIBRARY
 /* Collective chunk instrumentation properties */
 #define H5D_XFER_COLL_CHUNK_LINK_HARD_NAME        "coll_chunk_link_hard"

--- a/src/H5Dprivate.h
+++ b/src/H5Dprivate.h
@@ -79,11 +79,11 @@
 #define H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME                                                              \
     "local_no_collective_cause" /* cause of broken collective I/O in each process */
 #define H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME                                                             \
-    "global_no_collective_cause"                 /* cause of broken collective I/O in all processes */
-#define H5D_XFER_EDC_NAME       "err_detect"     /* EDC */
-#define H5D_XFER_FILTER_CB_NAME "filter_cb"      /* Filter callback function */
-#define H5D_XFER_CONV_CB_NAME   "type_conv_cb"   /* Type conversion callback function */
-#define H5D_XFER_XFORM_NAME     "data_transform" /* Data transform */
+    "global_no_collective_cause"                      /* cause of broken collective I/O in all processes */
+#define H5D_XFER_EDC_NAME         "err_detect"        /* EDC */
+#define H5D_XFER_FILTER_CB_NAME   "filter_cb"         /* Filter callback function */
+#define H5D_XFER_CONV_CB_NAME     "type_conv_cb"      /* Type conversion callback function */
+#define H5D_XFER_XFORM_NAME       "data_transform"    /* Data transform */
 #define H5D_XFER_DSET_IO_SEL_NAME "dset_io_selection" /* Dataset I/O selection */
 #ifdef H5_HAVE_INSTRUMENTED_LIBRARY
 /* Collective chunk instrumentation properties */

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -160,14 +160,14 @@
 #define H5D_XFER_XFORM_CMP   H5P__dxfr_xform_cmp
 #define H5D_XFER_XFORM_CLOSE H5P__dxfr_xform_close
 /* Definitions for dataset I/O selection property */
-#define H5D_XFER_DSET_IO_SEL_SIZE sizeof(H5S_t *)
-#define H5D_XFER_DSET_IO_SEL_DEF  NULL
+#define H5D_XFER_DSET_IO_SEL_SIZE  sizeof(H5S_t *)
+#define H5D_XFER_DSET_IO_SEL_DEF   NULL
 #define H5D_XFER_DSET_IO_SEL_COPY  H5P__dxfr_dset_io_hyp_sel_copy
 #define H5D_XFER_DSET_IO_SEL_CMP   H5P__dxfr_dset_io_hyp_sel_cmp
 #define H5D_XFER_DSET_IO_SEL_CLOSE H5P__dxfr_dset_io_hyp_sel_close
 #ifdef QAK
-#define H5D_XFER_DSET_IO_SEL_ENC  H5P__dxfr_edc_enc
-#define H5D_XFER_DSET_IO_SEL_DEC  H5P__dxfr_edc_dec
+#define H5D_XFER_DSET_IO_SEL_ENC H5P__dxfr_edc_enc
+#define H5D_XFER_DSET_IO_SEL_DEC H5P__dxfr_edc_dec
 #endif /* QAK */
 
 /******************/
@@ -275,8 +275,9 @@ static const H5Z_EDC_t H5D_def_enable_edc_g = H5D_XFER_EDC_DEF;       /* Default
 static const H5Z_cb_t  H5D_def_filter_cb_g  = H5D_XFER_FILTER_CB_DEF; /* Default value for filter callback */
 static const H5T_conv_cb_t H5D_def_conv_cb_g =
     H5D_XFER_CONV_CB_DEF; /* Default value for datatype conversion callback */
-static const void *H5D_def_xfer_xform_g = H5D_XFER_XFORM_DEF; /* Default value for data transform */
-static const H5S_t *H5D_def_dset_io_sel_g = H5D_XFER_DSET_IO_SEL_DEF; /* Default value for dataset I/O selection */
+static const void * H5D_def_xfer_xform_g = H5D_XFER_XFORM_DEF; /* Default value for data transform */
+static const H5S_t *H5D_def_dset_io_sel_g =
+    H5D_XFER_DSET_IO_SEL_DEF; /* Default value for dataset I/O selection */
 
 /*-------------------------------------------------------------------------
  * Function:    H5P__dxfr_reg_prop
@@ -435,9 +436,9 @@ H5P__dxfr_reg_prop(H5P_genclass_t *pclass)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINSERT, FAIL, "can't insert property into class")
 
     /* Register the dataset I/O selection property */
-    if (H5P__register_real(pclass, H5D_XFER_DSET_IO_SEL_NAME, H5D_XFER_DSET_IO_SEL_SIZE, &H5D_def_dset_io_sel_g, NULL,
-                           NULL, NULL, NULL, NULL,
-                           NULL, H5D_XFER_DSET_IO_SEL_COPY, H5D_XFER_DSET_IO_SEL_CMP,
+    if (H5P__register_real(pclass, H5D_XFER_DSET_IO_SEL_NAME, H5D_XFER_DSET_IO_SEL_SIZE,
+                           &H5D_def_dset_io_sel_g, NULL, NULL, NULL, NULL, NULL, NULL,
+                           H5D_XFER_DSET_IO_SEL_COPY, H5D_XFER_DSET_IO_SEL_CMP,
                            H5D_XFER_DSET_IO_SEL_CLOSE) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINSERT, FAIL, "can't insert property into class")
 
@@ -2148,8 +2149,8 @@ static herr_t
 H5P__dxfr_dset_io_hyp_sel_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
     H5S_t *orig_space = *(H5S_t **)value; /* Original dataspace for property */
-    H5S_t *new_space = NULL;            /* New dataspace for property */
-    herr_t ret_value = SUCCEED;         /* Return value */
+    H5S_t *new_space  = NULL;             /* New dataspace for property */
+    herr_t ret_value  = SUCCEED;          /* Return value */
 
     FUNC_ENTER_STATIC
 
@@ -2188,9 +2189,9 @@ done:
 static int
 H5P__dxfr_dset_io_hyp_sel_cmp(const void *_space1, const void *_space2, size_t H5_ATTR_UNUSED size)
 {
-    const H5S_t *const *space1 = (const H5S_t *const *)_space1; /* Create local aliases for values */
-    const H5S_t *const *space2 = (const H5S_t *const *)_space2; /* Create local aliases for values */
-    herr_t      ret_value = 0;                    /* Return value */
+    const H5S_t *const *space1    = (const H5S_t *const *)_space1; /* Create local aliases for values */
+    const H5S_t *const *space2    = (const H5S_t *const *)_space2; /* Create local aliases for values */
+    herr_t              ret_value = 0;                             /* Return value */
 
     FUNC_ENTER_STATIC_NOERR
 
@@ -2223,7 +2224,6 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5P__dxfr_dset_io_hyp_sel_cmp() */
 
-
 /*-------------------------------------------------------------------------
  * Function:    H5P__dxfr_dset_io_hyp_sel_close
  *
@@ -2239,8 +2239,8 @@ done:
 static herr_t
 H5P__dxfr_dset_io_hyp_sel_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *_value)
 {
-    H5S_t *space = *(H5S_t **)_value;   /* Dataspace for property */
-    herr_t ret_value = SUCCEED;         /* Return value */
+    H5S_t *space     = *(H5S_t **)_value; /* Dataspace for property */
+    herr_t ret_value = SUCCEED;           /* Return value */
 
     FUNC_ENTER_STATIC
 
@@ -2279,14 +2279,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op,
-                                      const hsize_t start[], const hsize_t stride[],
-                                      const hsize_t count[], const hsize_t block[])
+H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op, const hsize_t start[],
+                                      const hsize_t stride[], const hsize_t count[], const hsize_t block[])
 {
-    H5P_genplist_t * plist;                   /* Property list pointer */
-    H5S_t          * space;                   /* Dataspace to hold selection */
-    hbool_t          space_created = FALSE;   /* Whether a new dataspace has been created */
-    herr_t           ret_value     = SUCCEED; /* return value */
+    H5P_genplist_t *plist;                   /* Property list pointer */
+    H5S_t *         space;                   /* Dataspace to hold selection */
+    hbool_t         space_created = FALSE;   /* Whether a new dataspace has been created */
+    herr_t          ret_value     = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE7("e", "iIuSs*h*h*h*h", plist_id, rank, op, start, stride, count, block);
@@ -2317,31 +2316,31 @@ H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper
     /* See if a dataset I/O selection is already set, and free it if it is */
     if (H5P_peek(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "error getting dataset I/O selection")
-HDfprintf(stderr, "%s: space = %p\n", FUNC, space);
+    HDfprintf(stderr, "%s: space = %p\n", FUNC, space);
 
     /* Check for first time called */
     if (NULL == space) {
-        hsize_t dims[H5S_MAX_RANK];     /* Dimensions for new dataspace */
-        unsigned u;                     /* Local index variable */
+        hsize_t  dims[H5S_MAX_RANK]; /* Dimensions for new dataspace */
+        unsigned u;                  /* Local index variable */
 
         /* Initialize dimensions to largest possible actual size */
-        for(u = 0; u < rank; u++)
+        for (u = 0; u < rank; u++)
             dims[u] = (H5S_UNLIMITED - 1);
 
         /* Create dataspace of the correct dimensionality, with maximum dimensions */
         if (NULL == (space = H5S_create_simple(rank, dims, NULL)))
             HGOTO_ERROR(H5E_PLIST, H5E_CANTCREATE, FAIL, "unable to create dataspace for selection")
         space_created = TRUE;
-HDfprintf(stderr, "%s: new space = %p\n", FUNC, space);
+        HDfprintf(stderr, "%s: new space = %p\n", FUNC, space);
     } /* end if */
     else {
-//        int sndims;     /* Rank of existing dataspace */
+        //        int sndims;     /* Rank of existing dataspace */
 
-HDfprintf(stderr, "%s: second call\n", FUNC);
-HDabort();
+        HDfprintf(stderr, "%s: second call\n", FUNC);
+        HDabort();
 
-//#define H5S_GET_EXTENT_NDIMS(S)                 (H5S_get_simple_extent_ndims(S))
-// compare rank, if same, proceed, if not same possibly create new one, depending on op
+        //#define H5S_GET_EXTENT_NDIMS(S)                 (H5S_get_simple_extent_ndims(S))
+        // compare rank, if same, proceed, if not same possibly create new one, depending on op
     } /* end else */
 
     /* Set selection for dataspace */
@@ -2361,7 +2360,7 @@ HDabort();
     /* Update property list (takes ownership of dataspace, if new) */
     if (H5P_poke(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "error setting dataset I/O selection")
-    space_created = FALSE;      /* Reset now that property owns the dataspace */
+    space_created = FALSE; /* Reset now that property owns the dataspace */
 
 done:
     /* Cleanup on failure */
@@ -2371,4 +2370,3 @@ done:
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Pset_dataset_io_hyperslab_selection() */
-

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -159,6 +159,16 @@
 #define H5D_XFER_XFORM_COPY  H5P__dxfr_xform_copy
 #define H5D_XFER_XFORM_CMP   H5P__dxfr_xform_cmp
 #define H5D_XFER_XFORM_CLOSE H5P__dxfr_xform_close
+/* Definitions for dataset I/O selection property */
+#define H5D_XFER_DSET_IO_SEL_SIZE sizeof(H5S_t *)
+#define H5D_XFER_DSET_IO_SEL_DEF  NULL
+#define H5D_XFER_DSET_IO_SEL_COPY  H5P__dxfr_dset_io_hyp_sel_copy
+#define H5D_XFER_DSET_IO_SEL_CMP   H5P__dxfr_dset_io_hyp_sel_cmp
+#define H5D_XFER_DSET_IO_SEL_CLOSE H5P__dxfr_dset_io_hyp_sel_close
+#ifdef QAK
+#define H5D_XFER_DSET_IO_SEL_ENC  H5P__dxfr_edc_enc
+#define H5D_XFER_DSET_IO_SEL_DEC  H5P__dxfr_edc_dec
+#endif /* QAK */
 
 /******************/
 /* Local Typedefs */
@@ -196,6 +206,9 @@ static herr_t H5P__dxfr_xform_del(hid_t prop_id, const char *name, size_t size, 
 static herr_t H5P__dxfr_xform_copy(const char *name, size_t size, void *value);
 static int    H5P__dxfr_xform_cmp(const void *value1, const void *value2, size_t size);
 static herr_t H5P__dxfr_xform_close(const char *name, size_t size, void *value);
+static herr_t H5P__dxfr_dset_io_hyp_sel_copy(const char *name, size_t size, void *value);
+static int    H5P__dxfr_dset_io_hyp_sel_cmp(const void *value1, const void *value2, size_t size);
+static herr_t H5P__dxfr_dset_io_hyp_sel_close(const char *name, size_t size, void *value);
 
 /*********************/
 /* Package Variables */
@@ -263,6 +276,7 @@ static const H5Z_cb_t  H5D_def_filter_cb_g  = H5D_XFER_FILTER_CB_DEF; /* Default
 static const H5T_conv_cb_t H5D_def_conv_cb_g =
     H5D_XFER_CONV_CB_DEF; /* Default value for datatype conversion callback */
 static const void *H5D_def_xfer_xform_g = H5D_XFER_XFORM_DEF; /* Default value for data transform */
+static const H5S_t *H5D_def_dset_io_sel_g = H5D_XFER_DSET_IO_SEL_DEF; /* Default value for dataset I/O selection */
 
 /*-------------------------------------------------------------------------
  * Function:    H5P__dxfr_reg_prop
@@ -418,6 +432,13 @@ H5P__dxfr_reg_prop(H5P_genclass_t *pclass)
                            H5D_XFER_XFORM_SET, H5D_XFER_XFORM_GET, H5D_XFER_XFORM_ENC, H5D_XFER_XFORM_DEC,
                            H5D_XFER_XFORM_DEL, H5D_XFER_XFORM_COPY, H5D_XFER_XFORM_CMP,
                            H5D_XFER_XFORM_CLOSE) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTINSERT, FAIL, "can't insert property into class")
+
+    /* Register the dataset I/O selection property */
+    if (H5P__register_real(pclass, H5D_XFER_DSET_IO_SEL_NAME, H5D_XFER_DSET_IO_SEL_SIZE, &H5D_def_dset_io_sel_g, NULL,
+                           NULL, NULL, NULL, NULL,
+                           NULL, H5D_XFER_DSET_IO_SEL_COPY, H5D_XFER_DSET_IO_SEL_CMP,
+                           H5D_XFER_DSET_IO_SEL_CLOSE) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINSERT, FAIL, "can't insert property into class")
 
 done:
@@ -894,7 +915,7 @@ H5P__dxfr_xform_cmp(const void *_xform1, const void *_xform2, size_t H5_ATTR_UNU
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5P__dxfr_xform_copy() */
+} /* end H5P__dxfr_xform_cmp() */
 
 /*-------------------------------------------------------------------------
  * Function: H5P__dxfr_xform_close
@@ -2110,3 +2131,244 @@ H5P__dxfr_edc_dec(const void **_pp, void *_value)
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5P__dxfr_edc_dec() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5P__dxfr_dset_io_hyp_sel_copy
+ *
+ * Purpose:     Creates a copy of the dataset I/O selection.
+ *
+ * Return:	Non-negative on success/Negative on failure
+ *
+ * Programmer:	Quincey Koziol
+ *              Sunday, January 31, 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5P__dxfr_dset_io_hyp_sel_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
+{
+    H5S_t *orig_space = *(H5S_t **)value; /* Original dataspace for property */
+    H5S_t *new_space = NULL;            /* New dataspace for property */
+    herr_t ret_value = SUCCEED;         /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* If there's a dataspace I/O selection set, copy it */
+    if (orig_space) {
+        /* Make copy of dataspace */
+        if (NULL == (new_space = H5S_copy(orig_space, FALSE, TRUE)))
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "error copying the dataset I/O selection")
+
+        /* Set new value for property */
+        *(void **)value = new_space;
+    } /* end if */
+
+done:
+    /* Cleanup on error */
+    if (ret_value < 0)
+        if (new_space && H5S_close(new_space) < 0)
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "error closing dataset I/O selection dataspace")
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5P__dxfr_dset_io_hyp_sel_copy() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5P__dxfr_dset_io_hyp_sel_cmp
+ *
+ * Purpose:     Compare two dataset I/O selections.
+ *
+ * Return:      positive if VALUE1 is greater than VALUE2, negative if VALUE2 is
+ *		greater than VALUE1 and zero if VALUE1 and VALUE2 are equal.
+ *
+ * Programmer:	Quincey Koziol
+ *              Sunday, January 31, 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5P__dxfr_dset_io_hyp_sel_cmp(const void *_space1, const void *_space2, size_t H5_ATTR_UNUSED size)
+{
+    const H5S_t *const *space1 = (const H5S_t *const *)_space1; /* Create local aliases for values */
+    const H5S_t *const *space2 = (const H5S_t *const *)_space2; /* Create local aliases for values */
+    herr_t      ret_value = 0;                    /* Return value */
+
+    FUNC_ENTER_STATIC_NOERR
+
+    /* Sanity check */
+    HDassert(space1);
+    HDassert(space1);
+    HDassert(size == sizeof(H5S_t *));
+
+    /* Check for a property being set */
+    if (*space1 == NULL && *space2 != NULL)
+        HGOTO_DONE(-1);
+    if (*space1 != NULL && *space2 == NULL)
+        HGOTO_DONE(1);
+
+    if (*space1) {
+        HDassert(*space2);
+
+        /* Compare the extents of the dataspaces */
+        /* (Error & not-equal count the same) */
+        if (TRUE != H5S_extent_equal(*space1, *space2))
+            HGOTO_DONE(-1);
+
+        /* Compare the selection "shape" of the dataspaces */
+        /* (Error & not-equal count the same) */
+        if (TRUE != H5S_select_shape_same(*space1, *space2))
+            HGOTO_DONE(-1);
+    } /* end if */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5P__dxfr_dset_io_hyp_sel_cmp() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5P__dxfr_dset_io_hyp_sel_close
+ *
+ * Purpose:     Frees resources for dataset I/O selection
+ *
+ * Return:	Non-negative on success/Negative on failure
+ *
+ * Programmer:	Quincey Koziol
+ *              Sunday, January 31, 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5P__dxfr_dset_io_hyp_sel_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *_value)
+{
+    H5S_t *space = *(H5S_t **)_value;   /* Dataspace for property */
+    herr_t ret_value = SUCCEED;         /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Release any dataspace */
+    if (space && H5S_close(space) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "error closing dataset I/O selection dataspace")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5P__dxfr_dset_io_hyp_sel_close() */
+
+/*-------------------------------------------------------------------------
+ * Function:	H5Pset_dataset_io_hyperslab_selection
+ *
+ * Purpose:	H5Pset_dataset_io_hyperslab_selection() is designed to be used
+ *              in conjunction with using H5S_PLIST for the file dataspace
+ *              ID when making a call to H5Dread() or H5Dwrite().  When used
+ *              with H5S_PLIST, the selection created by one or more calls to
+ *              this routine is used for determining which dataset elements to
+ *              access.
+ *
+ *              'rank' is the dimensionality of the selection and determines
+ *              the size of the 'start', 'stride', 'count', and 'block' arrays.
+ *              'rank' must be between 1 and H5S_MAX_RANK, inclusive.
+ *
+ *              The 'op', 'start', 'stride', 'count', and 'block' parameters
+ *              behave identically to their behavior for H5Sselect_hyperslab(),
+ *              please see the documentation for that routine for details about
+ *              their use.
+ *
+ * Return:	Non-negative on success/Negative on failure
+ *
+ * Programmer:	Quincey Koziol
+ *              Saturday, January 30, 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op,
+                                      const hsize_t start[], const hsize_t stride[],
+                                      const hsize_t count[], const hsize_t block[])
+{
+    H5P_genplist_t * plist;                   /* Property list pointer */
+    H5S_t          * space;                   /* Dataspace to hold selection */
+    hbool_t          space_created = FALSE;   /* Whether a new dataspace has been created */
+    herr_t           ret_value     = SUCCEED; /* return value */
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE7("e", "iIuSs*h*h*h*h", plist_id, rank, op, start, stride, count, block);
+
+    /* Check arguments */
+    if (rank < 1 || rank > H5S_MAX_RANK)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid rank value: %u", rank)
+    if (!(op > H5S_SELECT_NOOP && op < H5S_SELECT_INVALID))
+        HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, FAIL, "invalid selection operation")
+    if (start == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'count' pointer is NULL")
+    if (stride != NULL) {
+        unsigned u; /* Local index variable */
+
+        /* Check for 0-sized strides */
+        for (u = 0; u < rank; u++)
+            if (stride[u] == 0)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid value - stride[%u]==0", u)
+    } /* end if */
+    if (count == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'start' pointer is NULL")
+    /* block is allowed to be NULL, and will be assumed to be all '1's when NULL */
+
+    /* Get the plist structure */
+    if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
+        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID")
+
+    /* See if a dataset I/O selection is already set, and free it if it is */
+    if (H5P_peek(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "error getting dataset I/O selection")
+HDfprintf(stderr, "%s: space = %p\n", FUNC, space);
+
+    /* Check for first time called */
+    if (NULL == space) {
+        hsize_t dims[H5S_MAX_RANK];     /* Dimensions for new dataspace */
+        unsigned u;                     /* Local index variable */
+
+        /* Initialize dimensions to largest possible actual size */
+        for(u = 0; u < rank; u++)
+            dims[u] = (H5S_UNLIMITED - 1);
+
+        /* Create dataspace of the correct dimensionality, with maximum dimensions */
+        if (NULL == (space = H5S_create_simple(rank, dims, NULL)))
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTCREATE, FAIL, "unable to create dataspace for selection")
+        space_created = TRUE;
+HDfprintf(stderr, "%s: new space = %p\n", FUNC, space);
+    } /* end if */
+    else {
+//        int sndims;     /* Rank of existing dataspace */
+
+HDfprintf(stderr, "%s: second call\n", FUNC);
+HDabort();
+
+//#define H5S_GET_EXTENT_NDIMS(S)                 (H5S_get_simple_extent_ndims(S))
+// compare rank, if same, proceed, if not same possibly create new one, depending on op
+    } /* end else */
+
+    /* Set selection for dataspace */
+    if (H5S_select_hyperslab(space, op, start, stride, count, block) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTSELECT, FAIL, "can't create selection")
+
+#ifdef QAK
+    /* Destroy previous data transform property */
+    if (H5Z_xform_destroy(data_xform_prop) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CLOSEERROR, FAIL, "unable to release data transform expression")
+
+    /* Create data transform info from expression */
+    if (NULL == (data_xform_prop = H5Z_xform_create(expression)))
+        HGOTO_ERROR(H5E_PLINE, H5E_NOSPACE, FAIL, "unable to create data transform info")
+#endif /* QAK */
+
+    /* Update property list (takes ownership of dataspace, if new) */
+    if (H5P_poke(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "error setting dataset I/O selection")
+    space_created = FALSE;      /* Reset now that property owns the dataspace */
+
+done:
+    /* Cleanup on failure */
+    if (ret_value < 0)
+        if (space_created && H5S_close(space) < 0)
+            HDONE_ERROR(H5E_PLINE, H5E_CLOSEERROR, FAIL, "unable to release dataspace")
+
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Pset_dataset_io_hyperslab_selection() */
+

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -22,16 +22,17 @@
 
 /* Public headers needed by this file */
 #include "H5public.h"
-#include "H5ACpublic.h"
-#include "H5Dpublic.h"
-#include "H5Fpublic.h"
-#include "H5FDpublic.h"
-#include "H5Ipublic.h"
-#include "H5Lpublic.h"
-#include "H5Opublic.h"
-#include "H5MMpublic.h"
-#include "H5Tpublic.h"
-#include "H5Zpublic.h"
+#include "H5ACpublic.h" /* Metadata cache                           */
+#include "H5Dpublic.h"  /* Datasets                                 */
+#include "H5Fpublic.h"  /* Files                                    */
+#include "H5FDpublic.h" /* File drivers                             */
+#include "H5Ipublic.h"  /* ID management                            */
+#include "H5Lpublic.h"  /* Links                                    */
+#include "H5MMpublic.h" /* Memory management                        */
+#include "H5Opublic.h"  /* Object headers                           */
+#include "H5Spublic.h"  /* Dataspaces                               */
+#include "H5Tpublic.h"  /* Datatypes                                */
+#include "H5Zpublic.h"  /* Data filters                             */
 
 /*****************/
 /* Public Macros */
@@ -5855,6 +5856,44 @@ H5_DLL herr_t H5Pget_mpio_actual_io_mode(hid_t plist_id, H5D_mpio_actual_io_mode
 H5_DLL herr_t H5Pget_mpio_no_collective_cause(hid_t plist_id, uint32_t *local_no_collective_cause,
                                               uint32_t *global_no_collective_cause);
 #endif /* H5_HAVE_PARALLEL */
+/**
+ *
+ * \ingroup DXPL
+ *
+ * \brief Sets a hyperslab file selection for a dataset I/O operation
+ *
+ * \param[in] plist_id Property list identifier
+ * \param[in] rank     Number of dimensions of selection
+ * \param[in] op       Operation to perform on current selection
+ * \param[in] start    Offset of start of hyperslab
+ * \param[in] stride   Hyperslab stride
+ * \param[in] count    Number of blocks included in hyperslab
+ * \param[in] block    Size of block in hyperslab
+ *
+ * \return \herr_t
+ *
+ * \details H5Pset_dataset_io_hyperslab_selection() is designed to be used
+ *          in conjunction with using #H5S_PLIST for the file dataspace
+ *          ID when making a call to H5Dread() or H5Dwrite().  When used
+ *          with #H5S_PLIST, the selection created by one or more calls to
+ *          this routine is used for determining which dataset elements to
+ *          access.
+ *
+ *          \p rank is the dimensionality of the selection and determines
+ *          the size of the \p start, \p stride, \p count, and \p block arrays.
+ *          \p rank must be between 1 and #H5S_MAX_RANK, inclusive.
+ *
+ *          The \op, \p start, \p stride, \p count, and \p block parameters
+ *          behave identically to their behavior for H5Sselect_hyperslab(),
+ *          please see the documentation for that routine for details about
+ *          their use.
+ *
+ * \since 1.13.0
+ *
+ */
+H5_DLL herr_t H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op,
+                                                 const hsize_t start[], const hsize_t stride[],
+                                                 const hsize_t count[], const hsize_t block[]);
 
 /* Link creation property list (LCPL) routines */
 /**
@@ -6926,6 +6965,7 @@ H5_DLL herr_t H5Pset_copy_object(hid_t plist_id, unsigned copy_options);
  *
  */
 H5_DLL herr_t H5Pset_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t func, void *op_data);
+
 
 /* Symbols defined for compatibility with previous versions of the HDF5 API.
  *

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -5892,8 +5892,8 @@ H5_DLL herr_t H5Pget_mpio_no_collective_cause(hid_t plist_id, uint32_t *local_no
  *
  */
 H5_DLL herr_t H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op,
-                                                 const hsize_t start[], const hsize_t stride[],
-                                                 const hsize_t count[], const hsize_t block[]);
+                                                    const hsize_t start[], const hsize_t stride[],
+                                                    const hsize_t count[], const hsize_t block[]);
 
 /* Link creation property list (LCPL) routines */
 /**
@@ -6965,7 +6965,6 @@ H5_DLL herr_t H5Pset_copy_object(hid_t plist_id, unsigned copy_options);
  *
  */
 H5_DLL herr_t H5Pset_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t func, void *op_data);
-
 
 /* Symbols defined for compatibility with previous versions of the HDF5 API.
  *

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -84,7 +84,7 @@ H5FL_ARR_DEFINE(hsize_t, H5S_MAX_RANK);
 static const H5I_class_t H5I_DATASPACE_CLS[1] = {{
     H5I_DATASPACE,            /* ID class value */
     0,                        /* Class flags */
-    2,                        /* # of reserved IDs for class */
+    3,                        /* # of reserved IDs for class */
     (H5I_free_t)H5S__close_cb /* Callback routine for closing objects of this class */
 }};
 

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -22,9 +22,9 @@
 #include "H5Ipublic.h"
 
 /* Define special dataspaces for dataset I/O operations */
-#define H5S_ALL       (hid_t)0
-#define H5S_BLOCK     (hid_t)1
-#define H5S_PLIST     (hid_t)2
+#define H5S_ALL   (hid_t)0
+#define H5S_BLOCK (hid_t)1
+#define H5S_PLIST (hid_t)2
 
 #define H5S_UNLIMITED HSIZE_UNDEF
 

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -21,9 +21,11 @@
 #include "H5public.h"
 #include "H5Ipublic.h"
 
-/* Define atomic datatypes */
+/* Define special dataspaces for dataset I/O operations */
 #define H5S_ALL       (hid_t)0
 #define H5S_BLOCK     (hid_t)1
+#define H5S_PLIST     (hid_t)2
+
 #define H5S_UNLIMITED HSIZE_UNDEF
 
 /* Define user-level maximum number of dimensions */

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -427,8 +427,7 @@ H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, hbool_t *acqui
  *--------------------------------------------------------------------------
  */
 herr_t
-H5TSmutex_acquire(unsigned int lock_count, hbool_t *acquired)
-{
+H5TSmutex_acquire(unsigned int lock_count, hbool_t *acquired){
     FUNC_ENTER_API_NAMECHECK_ONLY
 
         FUNC_LEAVE_API_NAMECHECK_ONLY(H5TS__mutex_acquire(&H5_g.init_lock, lock_count, acquired))}

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -427,7 +427,8 @@ H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, hbool_t *acqui
  *--------------------------------------------------------------------------
  */
 herr_t
-H5TSmutex_acquire(unsigned int lock_count, hbool_t *acquired){
+H5TSmutex_acquire(unsigned int lock_count, hbool_t *acquired)
+{
     FUNC_ENTER_API_NAMECHECK_ONLY
 
         FUNC_LEAVE_API_NAMECHECK_ONLY(H5TS__mutex_acquire(&H5_g.init_lock, lock_count, acquired))}

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -50,8 +50,8 @@
 /********************/
 
 /* Helper routines for read/write API calls */
-static herr_t H5VL__native_dataset_io_setup(H5D_t *dset, hid_t dxpl_id, hid_t file_space_id, hid_t mem_space_id,
-                                            H5S_t **file_space, H5S_t **mem_space);
+static herr_t H5VL__native_dataset_io_setup(H5D_t *dset, hid_t dxpl_id, hid_t file_space_id,
+                                            hid_t mem_space_id, H5S_t **file_space, H5S_t **mem_space);
 
 /*********************/
 /* Package Variables */
@@ -94,8 +94,8 @@ H5VL__native_dataset_io_setup(H5D_t *dset, hid_t dxpl_id, hid_t file_space_id, h
     else if (H5S_BLOCK == file_space_id)
         HGOTO_ERROR(H5E_DATASET, H5E_BADTYPE, FAIL, "H5S_BLOCK is not allowed for file dataspace")
     else if (H5S_PLIST == file_space_id) {
-        H5P_genplist_t * plist;                   /* Property list pointer */
-        H5S_t          * space;                   /* Dataspace to hold selection */
+        H5P_genplist_t *plist; /* Property list pointer */
+        H5S_t *         space; /* Dataspace to hold selection */
 
         /* Get the plist structure */
         if (NULL == (plist = H5P_object_verify(dxpl_id, H5P_DATASET_XFER)))
@@ -282,7 +282,8 @@ H5VL__native_dataset_read(void *obj, hid_t mem_type_id, hid_t mem_space_id, hid_
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dataset is not associated with a file")
 
     /* Get file & memory dataspaces */
-    if (H5VL__native_dataset_io_setup(dset, dxpl_id, file_space_id, mem_space_id, &file_space, &mem_space) < 0)
+    if (H5VL__native_dataset_io_setup(dset, dxpl_id, file_space_id, mem_space_id, &file_space, &mem_space) <
+        0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set up file and memory dataspaces")
 
     /* Set DXPL for operation */
@@ -332,7 +333,8 @@ H5VL__native_dataset_write(void *obj, hid_t mem_type_id, hid_t mem_space_id, hid
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dataset is not associated with a file")
 
     /* Get file & memory dataspaces */
-    if (H5VL__native_dataset_io_setup(dset, dxpl_id, file_space_id, mem_space_id, &file_space, &mem_space) < 0)
+    if (H5VL__native_dataset_io_setup(dset, dxpl_id, file_space_id, mem_space_id, &file_space, &mem_space) <
+        0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set up file and memory dataspaces")
 
     /* Set DXPL for operation */

--- a/test/CMakeTests.cmake
+++ b/test/CMakeTests.cmake
@@ -411,6 +411,7 @@ set (test_CLEANFILES
     mirror_wo/*
     event_set_*.h5
     h5s_block.h5
+    h5s_plist.h5
 )
 
 # Remove any output file left over from previous test run

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -176,7 +176,7 @@ CHECK_CLEANFILES+=accum.h5 cmpd_dset.h5 compact_dataset.h5 dataset.h5 dset_offse
     zero_chunk.h5 chunk_single.h5 swmr_non_latest.h5 \
     earray_hdr_fd.h5 farray_hdr_fd.h5 bt2_hdr_fd.h5 \
     storage_size.h5 dls_01_strings.h5 power2up.h5 version_bounds.h5 \
-    alloc_0sized.h5 h5s_block.h5 \
+    alloc_0sized.h5 h5s_block.h5 h5s_plist.h5 \
     extend.h5 istore.h5 extlinks*.h5 frspace.h5 links*.h5 \
     sys_file1 tfile[1-7].h5 th5s[1-4].h5 lheap.h5 fheap.h5 ohdr.h5 \
     stab.h5 extern_[1-5].h5 extern_[1-4][rw].raw gheap[0-4].h5 \

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -14984,13 +14984,13 @@ test_h5s_block(void)
 {
     hid_t    file_id                     = H5I_INVALID_HID; /* File ID */
     char     filename[FILENAME_BUF_SIZE] = "";
-    hid_t    dset_id                     = H5I_INVALID_HID;   /* Dataset ID */
-    hsize_t  dims[1]                     = {20}; /* Dataset's dataspace size */
-    hsize_t  start                       = 2;    /* Starting offset of hyperslab selection */
-    hsize_t  count                       = 10;   /* Count of hyperslab selection */
-    hid_t    file_space_id               = H5I_INVALID_HID;   /* File dataspace ID */
-    int      buf[20];                            /* Memory buffer for I/O */
-    unsigned u;                                  /* Local index variable */
+    hid_t    dset_id                     = H5I_INVALID_HID; /* Dataset ID */
+    hsize_t  dims[1]                     = {20};            /* Dataset's dataspace size */
+    hsize_t  start                       = 2;               /* Starting offset of hyperslab selection */
+    hsize_t  count                       = 10;              /* Count of hyperslab selection */
+    hid_t    file_space_id               = H5I_INVALID_HID; /* File dataspace ID */
+    int      buf[20];                                       /* Memory buffer for I/O */
+    unsigned u;                                             /* Local index variable */
     herr_t   ret;
 
     TESTING("contiguous memory buffers with H5S_BLOCK");
@@ -15106,17 +15106,17 @@ test_h5s_plist(void)
 {
     hid_t    file_id                     = H5I_INVALID_HID; /* File ID */
     char     filename[FILENAME_BUF_SIZE] = "";
-    hid_t    dset_id                     = H5I_INVALID_HID;   /* Dataset ID */
-    hsize_t  dims[1]                     = {20}; /* Dataset's dataspace size */
+    hid_t    dset_id                     = H5I_INVALID_HID; /* Dataset ID */
+    hsize_t  dims[1]                     = {20};            /* Dataset's dataspace size */
     hid_t    dxpl_id                     = H5I_INVALID_HID; /* Dataset xfer property list ID */
     hid_t    dxpl_id_copy                = H5I_INVALID_HID; /* Copy of dataset xfer property list ID */
-    hsize_t  start                       = 2;    /* Starting offset of hyperslab selection */
-    hsize_t  stride                      = 1;    /* Stride of hyperslab selection */
-    hsize_t  count                       = 10;   /* Count of hyperslab selection */
-    hsize_t  block                       = 1;    /* Block size of hyperslab selection */
-    hid_t    file_space_id               = H5I_INVALID_HID;   /* File dataspace ID */
-    int      buf[20];                            /* Memory buffer for I/O */
-    unsigned u;                                  /* Local index variable */
+    hsize_t  start                       = 2;               /* Starting offset of hyperslab selection */
+    hsize_t  stride                      = 1;               /* Stride of hyperslab selection */
+    hsize_t  count                       = 10;              /* Count of hyperslab selection */
+    hsize_t  block                       = 1;               /* Block size of hyperslab selection */
+    hid_t    file_space_id               = H5I_INVALID_HID; /* File dataspace ID */
+    int      buf[20];                                       /* Memory buffer for I/O */
+    unsigned u;                                             /* Local index variable */
     herr_t   ret;
 
     TESTING("dataset's dataspace selection for I/O in DXPL with H5S_PLIST");
@@ -15143,50 +15143,65 @@ test_h5s_plist(void)
     /* TESTS */
     /*********/
 
-
     /* Check error cases */
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* Bad rank */
-        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 0, H5S_SELECT_SET, &start, &stride, &count, &block);
-    } H5E_END_TRY;
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 0, H5S_SELECT_SET, &start, &stride, &count,
+                                                    &block);
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* Bad selection operator */
-        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_NOOP, &start, &stride, &count, &block);
-    } H5E_END_TRY;
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_NOOP, &start, &stride, &count,
+                                                    &block);
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* Bad start pointer */
-        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, NULL, &stride, &count, &block);
-    } H5E_END_TRY;
+        ret =
+            H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, NULL, &stride, &count, &block);
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* Bad stride value (stride of NULL is OK) */
         stride = 0;
-        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block);
+        ret    = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count,
+                                                    &block);
         stride = 1;
-    } H5E_END_TRY;
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* Bad count pointer */
-        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, NULL, &block);
-    } H5E_END_TRY;
+        ret =
+            H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, NULL, &block);
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
 
     /* Block pointer is allowed to be NULL */
 
-    H5E_BEGIN_TRY {
+    H5E_BEGIN_TRY
+    {
         /* H5S_PLIST for memory dataspace */
         ret = H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_PLIST, H5S_ALL, H5P_DEFAULT, buf);
-    } H5E_END_TRY;
+    }
+    H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR
-
 
     /* Write the entire dataset */
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
@@ -15208,7 +15223,8 @@ test_h5s_plist(void)
     HDmemset(buf, 0, sizeof(buf));
 
     /* Set valid selection in DXPL */
-    if(H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block) < 0)
+    if (H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block) <
+        0)
         FAIL_STACK_ERROR
 
     /* Read a hyperslab from the file to the first 10 elements of the buffer */
@@ -15696,9 +15712,9 @@ main(void)
             } /* end for new_format */
         }     /* end for minimized_ohdr */
     }         /* end for paged */
-#else /* QAK */
-HDfprintf(stderr, "Uncomment tests!\n");
-#endif /* QAK */
+#else         /* QAK */
+    HDfprintf(stderr, "Uncomment tests!\n");
+#endif        /* QAK */
 
     /* Close property lists */
     if (H5Pclose(fapl2) < 0)

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -84,6 +84,7 @@ const char *FILENAME[] = {"dataset",             /* 0 */
                           "version_bounds",      /* 25 */
                           "alloc_0sized",        /* 26 */
                           "h5s_block",           /* 27 */
+                          "h5s_plist",           /* 28 */
                           NULL};
 
 #define OHMIN_FILENAME_A "ohdr_min_a"
@@ -14981,13 +14982,13 @@ error:
 static herr_t
 test_h5s_block(void)
 {
-    hid_t    file_id                     = -1; /* File ID */
+    hid_t    file_id                     = H5I_INVALID_HID; /* File ID */
     char     filename[FILENAME_BUF_SIZE] = "";
-    hid_t    dset_id                     = -1;   /* Dataset ID */
+    hid_t    dset_id                     = H5I_INVALID_HID;   /* Dataset ID */
     hsize_t  dims[1]                     = {20}; /* Dataset's dataspace size */
     hsize_t  start                       = 2;    /* Starting offset of hyperslab selection */
     hsize_t  count                       = 10;   /* Count of hyperslab selection */
-    hid_t    file_space_id               = -1;   /* File dataspace ID */
+    hid_t    file_space_id               = H5I_INVALID_HID;   /* File dataspace ID */
     int      buf[20];                            /* Memory buffer for I/O */
     unsigned u;                                  /* Local index variable */
     herr_t   ret;
@@ -15086,6 +15087,186 @@ error:
 
     return FAIL;
 } /* end test_h5s_block() */
+
+/*-----------------------------------------------------------------------------
+ * Function:   test_h5s_plist
+ *
+ * Purpose:    Test the H5S_PLIST feature.
+ *
+ * Return:     Success/pass:   0
+ *             Failure/error: -1
+ *
+ * Programmer: Quincey Koziol
+ *             28 January 2021
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+test_h5s_plist(void)
+{
+    hid_t    file_id                     = H5I_INVALID_HID; /* File ID */
+    char     filename[FILENAME_BUF_SIZE] = "";
+    hid_t    dset_id                     = H5I_INVALID_HID;   /* Dataset ID */
+    hsize_t  dims[1]                     = {20}; /* Dataset's dataspace size */
+    hid_t    dxpl_id                     = H5I_INVALID_HID; /* Dataset xfer property list ID */
+    hid_t    dxpl_id_copy                = H5I_INVALID_HID; /* Copy of dataset xfer property list ID */
+    hsize_t  start                       = 2;    /* Starting offset of hyperslab selection */
+    hsize_t  stride                      = 1;    /* Stride of hyperslab selection */
+    hsize_t  count                       = 10;   /* Count of hyperslab selection */
+    hsize_t  block                       = 1;    /* Block size of hyperslab selection */
+    hid_t    file_space_id               = H5I_INVALID_HID;   /* File dataspace ID */
+    int      buf[20];                            /* Memory buffer for I/O */
+    unsigned u;                                  /* Local index variable */
+    herr_t   ret;
+
+    TESTING("dataset's dataspace selection for I/O in DXPL with H5S_PLIST");
+
+    /*********/
+    /* SETUP */
+    /*********/
+    if (NULL == h5_fixname(FILENAME[28], H5P_DEFAULT, filename, sizeof(filename)))
+        TEST_ERROR
+    if (H5I_INVALID_HID == (file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)))
+        FAIL_STACK_ERROR
+    if ((file_space_id = H5Screate_simple(1, dims, NULL)) < 0)
+        FAIL_STACK_ERROR
+    if ((dset_id = H5Dcreate2(file_id, "dset", H5T_NATIVE_INT, file_space_id, H5P_DEFAULT, H5P_DEFAULT,
+                              H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR
+    if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
+        FAIL_STACK_ERROR
+
+    for (u = 0; u < 20; u++)
+        buf[u] = (int)u;
+
+    /*********/
+    /* TESTS */
+    /*********/
+
+
+    /* Check error cases */
+    H5E_BEGIN_TRY {
+        /* Bad rank */
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 0, H5S_SELECT_SET, &start, &stride, &count, &block);
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+    H5E_BEGIN_TRY {
+        /* Bad selection operator */
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_NOOP, &start, &stride, &count, &block);
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+    H5E_BEGIN_TRY {
+        /* Bad start pointer */
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, NULL, &stride, &count, &block);
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+    H5E_BEGIN_TRY {
+        /* Bad stride value (stride of NULL is OK) */
+        stride = 0;
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block);
+        stride = 1;
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+    H5E_BEGIN_TRY {
+        /* Bad count pointer */
+        ret = H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, NULL, &block);
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+
+    /* Block pointer is allowed to be NULL */
+
+    H5E_BEGIN_TRY {
+        /* H5S_PLIST for memory dataspace */
+        ret = H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_PLIST, H5S_ALL, H5P_DEFAULT, buf);
+    } H5E_END_TRY;
+    if (ret == SUCCEED)
+        TEST_ERROR
+
+
+    /* Write the entire dataset */
+    if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
+        FAIL_STACK_ERROR
+
+    /* Reset the memory buffer */
+    HDmemset(buf, 0, sizeof(buf));
+
+    /* Read the entire dataset */
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
+        FAIL_STACK_ERROR
+
+    /* Verify the data read in */
+    for (u = 0; u < 20; u++)
+        if (buf[u] != (int)u)
+            TEST_ERROR
+
+    /* Reset the memory buffer */
+    HDmemset(buf, 0, sizeof(buf));
+
+    /* Set valid selection in DXPL */
+    if(H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block) < 0)
+        FAIL_STACK_ERROR
+
+    /* Read a hyperslab from the file to the first 10 elements of the buffer */
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id, buf) < 0)
+        FAIL_STACK_ERROR
+
+    /* Verify the data read in */
+    for (u = 0; u < count; u++)
+        if (buf[u] != (int)(u + start))
+            TEST_ERROR
+
+    /* Reset the memory buffer */
+    HDmemset(buf, 0, sizeof(buf));
+
+    /* Check for copying property list w/selection */
+    if ((dxpl_id_copy = H5Pcopy(dxpl_id)) < 0)
+        FAIL_STACK_ERROR
+
+    /* Read a hyperslab from the file to the first 10 elements of the buffer */
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id_copy, buf) < 0)
+        FAIL_STACK_ERROR
+
+    /* Verify the data read in */
+    for (u = 0; u < count; u++)
+        if (buf[u] != (int)(u + start))
+            TEST_ERROR
+
+    /************/
+    /* TEARDOWN */
+    /************/
+    if (FAIL == H5Pclose(dxpl_id_copy))
+        FAIL_STACK_ERROR
+    if (FAIL == H5Pclose(dxpl_id))
+        FAIL_STACK_ERROR
+    if (FAIL == H5Sclose(file_space_id))
+        FAIL_STACK_ERROR
+    if (FAIL == H5Dclose(dset_id))
+        FAIL_STACK_ERROR
+    if (FAIL == H5Fclose(file_id))
+        FAIL_STACK_ERROR
+
+    PASSED();
+
+    return SUCCEED;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dxpl_id_copy);
+        H5Pclose(dxpl_id);
+        H5Sclose(file_space_id);
+        H5Dclose(dset_id);
+        H5Fclose(file_id);
+    }
+    H5E_END_TRY;
+
+    return FAIL;
+} /* end test_h5s_plist() */
 
 /*-----------------------------------------------------------------------------
  * Function:   test_0sized_dset_metadata_alloc
@@ -15386,6 +15567,7 @@ main(void)
 
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
+#ifdef QAK
     /* Test with paged aggregation enabled or not */
     for (paged = FALSE; paged <= TRUE; paged++) {
 
@@ -15514,6 +15696,9 @@ main(void)
             } /* end for new_format */
         }     /* end for minimized_ohdr */
     }         /* end for paged */
+#else /* QAK */
+HDfprintf(stderr, "Uncomment tests!\n");
+#endif /* QAK */
 
     /* Close property lists */
     if (H5Pclose(fapl2) < 0)
@@ -15535,6 +15720,7 @@ main(void)
     /* Tests that use their own file */
     nerrors += (test_object_header_minimization_dcpl() < 0 ? 1 : 0);
     nerrors += (test_h5s_block() < 0 ? 1 : 0);
+    nerrors += (test_h5s_plist() < 0 ? 1 : 0);
 
     /* Run misc tests */
     nerrors += (dls_01_main() < 0 ? 1 : 0);


### PR DESCRIPTION
Adds 'H5S_PLIST' (to H5S_ALL and H5S_BLOCK) for dataspace to H5Dread and H5Dwrite, and H5Pset_dataset_io_hyperslab_selection to set the selection in the DXPL (passed to H5Dread/H5Dwrite).  This allows asynchronous operations to avoid blocking on calling H5Dget_space.